### PR TITLE
fix node_modules missing in container after mounting volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "3617:3617"
     volumes:
       - ".:/usr/src/app"
+      - "/usr/src/app/node_modules"
   signalhub:
     image: "santaka/signalhub"
     ports:


### PR DESCRIPTION
### Why

When setting up the development environment using docker, the `node_modules` inside the container was being overridden after mounting project volume.

### Solution

This PR solves this issue by mounting another volume for `node_modules`

