### PR TITLE
include and use a Dockerfile for signalhub service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - ".:/usr/src/app"
       - "/usr/src/app/node_modules"
   signalhub:
-    image: "santaka/signalhub"
+    build:
+      context: .
+      dockerfile: ./signalhub.Dockerfile
     ports:
-      - "3618:8080"
+      - "3618:3618"

--- a/signalhub.Dockerfile
+++ b/signalhub.Dockerfile
@@ -2,6 +2,8 @@ FROM node:lts-alpine
 
 RUN npm install -g signalhub
 
+EXPOSE 3618
+
 ENTRYPOINT [ "signalhub" ]
 
-CMD [ "listen", "-p", "8080" ]
+CMD [ "listen", "-p", "3618" ]


### PR DESCRIPTION
### Why

Right now, we are maintaining a separete repository for [signalhub docker service](https://github.com/santakadev/docker-signalhub). 

With the current project status, we preffer to keep all the code in the same repository. See https://github.com/CodelyTV/p2p-editor/pull/27#pullrequestreview-209989046
