### PR TITLE
use hypercore JSON value encoding

### DIFF
--- a/src/change-log.js
+++ b/src/change-log.js
@@ -6,7 +6,7 @@ class ChangeLog extends EventEmitter {
 
   constructor(key) {
     super()
-    this.log = new hypercore(ram, key)
+    this.log = new hypercore(ram, key, {valueEncoding: 'json'})
 
     this.log.on('ready', () => {
       this.emit('change_log.loaded', this.log.key.toString('hex'))
@@ -14,12 +14,12 @@ class ChangeLog extends EventEmitter {
 
     this.log.createReadStream({live: true})
       .on('data', (data) => {
-        this.emit('change_log.changes_applied', JSON.parse(data))
+        this.emit('change_log.changes_applied', data)
       })
   }
 
   append(data) {
-    this.log.append(JSON.stringify(data))
+    this.log.append(data)
   } 
 
   replicate(peer, options) {


### PR DESCRIPTION
Using this option, is no longer needed to execute `JSON.parse` and `JSON.stringify` every time we want to write or read the database.

This force us to use always JSON, but this is OK for our use case.